### PR TITLE
Removed can overlap

### DIFF
--- a/src/constants/error.constants.ts
+++ b/src/constants/error.constants.ts
@@ -380,7 +380,7 @@ const ERRORS = {
 		},
 		conflicts: {
 			title: 'Conflicting Schedule!',
-			message: 'There is another reservation at this time.',
+			message: 'There is another reservation at this time for this employee.',
 		},
 		gender_mismatch: {
 			title: 'Gender Mismatch!',

--- a/src/constants/label.constants.ts
+++ b/src/constants/label.constants.ts
@@ -63,7 +63,6 @@ const LABELS = {
 		feet: 'Feet',
 		acupuncture: 'Acupuncture',
 		beds_required: 'Beds Required',
-		can_overlap: 'Can Overlap',
 		color: 'Color',
 	},
 	vip_package: {

--- a/src/constants/name.constants.ts
+++ b/src/constants/name.constants.ts
@@ -55,7 +55,6 @@ const NAMES = {
 		feet: 'feet',
 		acupuncture: 'acupuncture',
 		beds_required: 'beds_required',
-		can_overlap: 'can_overlap',
 	},
 	vip_package: {
 		serial: 'serial',

--- a/src/locales/cn_simp/translation.json
+++ b/src/locales/cn_simp/translation.json
@@ -168,8 +168,6 @@
     "B": "B",
     "F": "F",
     "A": "A",
-    "Can Overlap": "Can Overlap",
-    "Cannot Overlap": "Cannot Overlap",
     "Delete Service": "删除服务项目: {{service}}",
     "Are you sure you want to delete this service? This action cannot be reversed.": "请确认是否要删除？",
 

--- a/src/locales/cn_trad/translation.json
+++ b/src/locales/cn_trad/translation.json
@@ -168,8 +168,6 @@
     "B": "B",
     "F": "F",
     "A": "A",
-    "Can Overlap": "Can Overlap",
-    "Cannot Overlap": "Cannot Overlap",
     "Delete Service": "刪除服務項目: {{service}}",
     "Are you sure you want to delete this service? This action cannot be reversed.": "請確認是否要刪除？",
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -168,8 +168,6 @@
     "B": "B",
     "F": "F",
     "A": "A",
-    "Can Overlap": "Can Overlap",
-    "Cannot Overlap": "Cannot Overlap",
     "Delete Service": "Delete Service: {{service}}",
     "Are you sure you want to delete this service? This action cannot be reversed.": "Are you sure you want to delete this service? This action cannot be reversed.",
 
@@ -331,7 +329,7 @@
     "No beds available!": "No beds available!",
     "Bed Conflict": "There are {{max}}/{{max}} beds being used at this time. Please choose another time.",
     "Conflicting Schedule!": "Conflicting Schedule!",
-    "There is another reservation at this time. Please choose another time or employee.": "There is another reservation at this time. Please choose another time or employee.",
+    "There is another reservation at this time for this employee.": "There is another reservation at this time for this employee.",
 
     "You are missing a required input.": "You are missing a required input.",
     "An input is invalid.": "An input is invalid.",

--- a/src/models/Service.Model.ts
+++ b/src/models/Service.Model.ts
@@ -10,7 +10,6 @@ export default interface Service {
 	feet: number;
 	acupuncture: number;
 	beds_required: number;
-	can_overlap: boolean;
 	color: ServiceColor;
 	created_at: Date;
 	updated_at: Date;

--- a/src/models/requests/Service.Request.Model.ts
+++ b/src/models/requests/Service.Request.Model.ts
@@ -9,7 +9,6 @@ export interface UpdateServiceRequest {
 	feet?: number;
 	acupuncture?: number;
 	beds_required?: number;
-	can_overlap?: boolean;
 	color?: ServiceColor;
 }
 
@@ -22,6 +21,5 @@ export interface AddServiceRequest {
 	feet?: number;
 	acupuncture?: number;
 	beds_required: number;
-	can_overlap?: boolean;
 	color: ServiceColor;
 }

--- a/src/page/bigfeet/components/miscallaneous/modals/scheduler/calendar/AddReservation.Component.tsx
+++ b/src/page/bigfeet/components/miscallaneous/modals/scheduler/calendar/AddReservation.Component.tsx
@@ -112,7 +112,6 @@ const AddReservation: FC<AddReservationProp> = ({
 		useState<boolean>(true);
 	const [invalidInput, setInvalidInput] = useState<boolean>(false);
 	const [noBeds, setNoBeds] = useState<boolean>(false);
-	const [conflict, setConflict] = useState<boolean>(false);
 	const [genderMismatch, setGenderMismatch] = useState<boolean>(false);
 
 	const [openBedWarningModal, setOpenBedWarningModal] =
@@ -279,21 +278,14 @@ const AddReservation: FC<AddReservationProp> = ({
 					);
 
 					if (reservationConflict) {
-						setConflict(true);
 						setOpenConflictWarningModal(true);
-					} else {
-						setConflict(false);
 					}
-				} else {
-					setConflict(false);
 				}
 			} else {
 				setNoBeds(false);
-				setConflict(false);
 			}
 		} else {
 			setNoBeds(false);
-			setConflict(false);
 		}
 	}, [dateInput, employeeIdInput, serviceIdInput]);
 
@@ -581,7 +573,6 @@ const AddReservation: FC<AddReservationProp> = ({
 					!creatable ||
 					missingRequiredInput ||
 					invalidInput ||
-					conflict ||
 					noBeds ||
 					genderMismatch
 				}
@@ -592,8 +583,6 @@ const AddReservation: FC<AddReservationProp> = ({
 						? t(ERRORS.required)
 						: invalidInput
 						? t(ERRORS.invalid)
-						: conflict
-						? t(ERRORS.warnings.conflicts.title)
 						: noBeds
 						? t(ERRORS.warnings.no_beds.title)
 						: genderMismatch

--- a/src/page/bigfeet/components/miscallaneous/modals/scheduler/calendar/EditReservation.Component.tsx
+++ b/src/page/bigfeet/components/miscallaneous/modals/scheduler/calendar/EditReservation.Component.tsx
@@ -103,15 +103,6 @@ const EditReservation: FC<EditReservationProp> = ({
 
 	const { date } = useScheduleDateContext();
 
-	const [openAddModal, setOpenAddModal] = useState(false);
-	const [openDeleteModal, setOpenDeleteModal] = useState(false);
-	const [openBedWarningModal, setOpenBedWarningModal] =
-		useState<boolean>(false);
-	const [openConflictWarningModal, setOpenConflictWarningModal] =
-		useState<boolean>(false);
-	const [openGenderMismatchWarningModel, setOpenGenderMismatchWarningModal] =
-		useState<boolean>(false);
-
 	const [dateInput, setDateInput] = useState<Date | null>(
 		reservation.reserved_date
 	);
@@ -181,8 +172,17 @@ const EditReservation: FC<EditReservationProp> = ({
 		useState<boolean>(false);
 	const [invalidInput, setInvalidInput] = useState<boolean>(false);
 	const [noBeds, setNoBeds] = useState<boolean>(false);
-	const [conflict, setConflict] = useState<boolean>(false);
 	const [genderMismatch, setGenderMismatch] = useState<boolean>(false);
+
+	const [openAddModal, setOpenAddModal] = useState(false);
+	const [openDeleteModal, setOpenDeleteModal] = useState(false);
+
+	const [openBedWarningModal, setOpenBedWarningModal] =
+		useState<boolean>(false);
+	const [openConflictWarningModal, setOpenConflictWarningModal] =
+		useState<boolean>(false);
+	const [openGenderMismatchWarningModel, setOpenGenderMismatchWarningModal] =
+		useState<boolean>(false);
 
 	const userQuery = useUserQuery({ gettable: true, staleTime: Infinity });
 	const user: User = userQuery.data;
@@ -476,21 +476,14 @@ const EditReservation: FC<EditReservationProp> = ({
 					);
 
 					if (reservationConflict) {
-						setConflict(true);
 						setOpenConflictWarningModal(true);
-					} else {
-						setConflict(false);
 					}
-				} else {
-					setConflict(false);
 				}
 			} else {
 				setNoBeds(false);
-				setConflict(false);
 			}
 		} else {
 			setNoBeds(false);
-			setConflict(false);
 		}
 	}, [dateInput, employeeIdInput, serviceIdInput]);
 
@@ -1096,7 +1089,6 @@ const EditReservation: FC<EditReservationProp> = ({
 					!changesMade ||
 					missingRequiredInput ||
 					invalidInput ||
-					conflict ||
 					noBeds ||
 					genderMismatch
 				}
@@ -1109,8 +1101,6 @@ const EditReservation: FC<EditReservationProp> = ({
 						? t(ERRORS.required)
 						: invalidInput
 						? t(ERRORS.invalid)
-						: conflict
-						? t(ERRORS.warnings.conflicts.title)
 						: noBeds
 						? t(ERRORS.warnings.no_beds.title)
 						: genderMismatch

--- a/src/page/bigfeet/components/miscallaneous/modals/scheduler/calendar/MoveReservation.Component.tsx
+++ b/src/page/bigfeet/components/miscallaneous/modals/scheduler/calendar/MoveReservation.Component.tsx
@@ -61,16 +61,15 @@ const MoveReservation: FC<MoveReservationProp> = ({
 
 	const { date } = useScheduleDateContext();
 
+	const [noBeds, setNoBeds] = useState<boolean>(false);
+	const [genderMismatch, setGenderMismatch] = useState<boolean>(false);
+
 	const [openBedWarningModal, setOpenBedWarningModal] =
 		useState<boolean>(false);
 	const [openConflictWarningModal, setOpenConflictWarningModal] =
 		useState<boolean>(false);
 	const [openGenderMismatchWarningModel, setOpenGenderMismatchWarningModal] =
 		useState<boolean>(false);
-
-	const [noBeds, setNoBeds] = useState<boolean>(false);
-	const [conflict, setConflict] = useState<boolean>(false);
-	const [genderMismatch, setGenderMismatch] = useState<boolean>(false);
 
 	const userQuery = useUserQuery({ gettable: true, staleTime: Infinity });
 	const user: User = userQuery.data;
@@ -143,10 +142,7 @@ const MoveReservation: FC<MoveReservationProp> = ({
 		);
 
 		if (reservationConflict) {
-			setConflict(true);
 			setOpenConflictWarningModal(true);
-		} else {
-			setConflict(false);
 		}
 	}, []);
 
@@ -254,12 +250,10 @@ const MoveReservation: FC<MoveReservationProp> = ({
 					onCancel();
 					setOpen(false);
 				}}
-				disabledEdit={!editable || conflict || noBeds || genderMismatch}
+				disabledEdit={!editable || noBeds || genderMismatch}
 				editMissingPermissionMessage={
 					!editable
 						? t(ERRORS.reservation.permissions.edit)
-						: conflict
-						? t(ERRORS.warnings.conflicts.title)
 						: noBeds
 						? t(ERRORS.warnings.no_beds.title)
 						: genderMismatch

--- a/src/page/bigfeet/components/miscallaneous/modals/scheduler/calendar/ReservationAddOn.Component.tsx
+++ b/src/page/bigfeet/components/miscallaneous/modals/scheduler/calendar/ReservationAddOn.Component.tsx
@@ -52,15 +52,14 @@ const ReservationAddOn: FC<ReservationAddOnProp> = ({
 
 	const [serviceIdInput, setServiceIdInput] = useState<number | null>(null);
 
+	const [noBeds, setNoBeds] = useState<boolean>(false);
+
 	const [missingRequiredInput, setMissingRequiredInput] =
 		useState<boolean>(true);
 	const [openBedWarningModal, setOpenBedWarningModal] =
 		useState<boolean>(false);
 	const [openConflictWarningModal, setOpenConflictWarningModal] =
 		useState<boolean>(false);
-
-	const [noBeds, setNoBeds] = useState<boolean>(false);
-	const [conflict, setConflict] = useState<boolean>(false);
 
 	const userQuery = useUserQuery({ gettable: true, staleTime: Infinity });
 	const user: User = userQuery.data;
@@ -150,17 +149,12 @@ const ReservationAddOn: FC<ReservationAddOnProp> = ({
 				);
 
 				if (reservationConflict) {
-					setConflict(true);
 					setOpenConflictWarningModal(true);
-				} else {
-					setConflict(false);
 				}
 			} else {
-				setConflict(false);
 				setNoBeds(false);
 			}
 		} else {
-			setConflict(false);
 			setNoBeds(false);
 		}
 	}, [serviceIdInput]);
@@ -264,14 +258,12 @@ const ReservationAddOn: FC<ReservationAddOnProp> = ({
 
 			<AddBottom
 				onCancel={() => setOpen(false)}
-				disabledAdd={!creatable || missingRequiredInput || conflict || noBeds}
+				disabledAdd={!creatable || missingRequiredInput || noBeds}
 				addMissingPermissionMessage={
 					!creatable
 						? t(ERRORS.reservation.permissions.add)
 						: missingRequiredInput
 						? t(ERRORS.required)
-						: conflict
-						? t(ERRORS.warnings.conflicts.title)
 						: noBeds
 						? t(ERRORS.warnings.no_beds.title)
 						: ''

--- a/src/page/bigfeet/components/miscallaneous/modals/service/AddService.Component.tsx
+++ b/src/page/bigfeet/components/miscallaneous/modals/service/AddService.Component.tsx
@@ -12,9 +12,6 @@ import AddInput from '../../add/AddInput.Component';
 import AddMinute from '../../add/AddMinute.Component';
 import AddNumber from '../../add/AddNumber.Component';
 import AddPayRate from '../../add/AddPayRate.Component';
-import AddToggleSwitch, {
-	ToggleColor,
-} from '../../add/AddToggleSwitch.Component';
 
 import AddBodyFeetAcupunctureService from '../../../services/components/AddBodyFeetAcupunctureService.Component';
 
@@ -53,7 +50,6 @@ const AddService: FC<AddServiceProp> = ({
 	const [feetInput, setFeetInput] = useState<number | null>(0);
 	const [acupunctureInput, setAcupunctureInput] = useState<number | null>(0);
 	const [bedsRequiredInput, setBedsRequiredInput] = useState<number | null>(0);
-	const [canOverlapInput, setCanOverlapInput] = useState<boolean>(false);
 	const [colorInput, setColorInput] = useState<ServiceColor | null>(null);
 
 	const [invalidServiceName, setInvalidServiceName] = useState<boolean>(false);
@@ -129,7 +125,6 @@ const AddService: FC<AddServiceProp> = ({
 		const feet: number = feetInput as number;
 		const acupuncture: number = acupunctureInput as number;
 		const beds_required: number = bedsRequiredInput as number;
-		const can_overlap: boolean = canOverlapInput as boolean;
 		const color: ServiceColor = colorInput as ServiceColor;
 
 		const addServiceRequest: AddServiceRequest = {
@@ -141,7 +136,6 @@ const AddService: FC<AddServiceProp> = ({
 			feet,
 			acupuncture,
 			beds_required,
-			can_overlap,
 			color,
 		};
 
@@ -279,17 +273,6 @@ const AddService: FC<AddServiceProp> = ({
 									requiredMessage: ERRORS.service.beds_required.required,
 								}}
 								placeholder={PLACEHOLDERS.service.beds_required}
-							/>
-
-							<AddToggleSwitch
-								setChecked={setCanOverlapInput}
-								checked={canOverlapInput}
-								falseText={t('Cannot Overlap')}
-								trueText={t('Can Overlap')}
-								toggleColour={ToggleColor.GREEN}
-								label={LABELS.service.can_overlap}
-								name={NAMES.service.can_overlap}
-								disabled={false}
 							/>
 
 							<AddDropDown

--- a/src/page/bigfeet/components/scheduler/Calendar/components/Reservation.Component.tsx
+++ b/src/page/bigfeet/components/scheduler/Calendar/components/Reservation.Component.tsx
@@ -28,6 +28,7 @@ import User from '../../../../../../models/User.Model';
 import { useEmployeesQuery } from '../../../../../hooks/employee.hooks';
 import { useSchedulesQuery } from '../../../../../hooks/schedule.hooks';
 import { useUserQuery } from '../../../../../hooks/profile.hooks';
+import { getReservationOverlappingOrder } from '../../../../../../utils/reservation.utils';
 
 interface ReservationTagProp {
 	reservation: Reservation;
@@ -133,6 +134,14 @@ const ReservationTag: FC<ReservationTagProp> = ({
 
 	const time = reservation.service.time;
 	const height = ((time / 60) * 100).toString() + '%';
+
+	const left = `${
+		30 *
+		getReservationOverlappingOrder(
+			reservation,
+			schedules.flatMap((schedule) => schedule.reservations)
+		)
+	}px`;
 
 	const tipLocation =
 		startHour <= 12
@@ -307,8 +316,9 @@ const ReservationTag: FC<ReservationTagProp> = ({
 					gridRowStart: rowStart,
 					marginTop: topMargin,
 					height: height,
+					left: left,
 				}}
-				className={`row-span-2 ${completionColour} border-4 rounded-lg mx-1 p-1 flex flex-row cursor-move overflow-visible z-[2] hover:z-[3] group`}>
+				className={`row-span-2 ${completionColour} border-4 rounded-lg mx-1 p-1 flex flex-row cursor-move overflow-visible z-[2] hover:z-[3] group relative`}>
 				<span className={tipLocation}>
 					{serviceText}
 					<br />

--- a/src/page/bigfeet/components/services/components/EditService.Component.tsx
+++ b/src/page/bigfeet/components/services/components/EditService.Component.tsx
@@ -8,14 +8,11 @@ import PermissionsButton, {
 	ButtonType,
 } from '../../miscallaneous/PermissionsButton.Component.tsx';
 
-import { ToggleColor } from '../../miscallaneous/add/AddToggleSwitch.Component.tsx';
-
 import EditableDropDown from '../../miscallaneous/editable/EditableDropDown.Component.tsx';
 import EditableInput from '../../miscallaneous/editable/EditableInput.Component.tsx';
 import EditableMinute from '../../miscallaneous/editable/EditableMinute.Component.tsx';
 import EditableNumber from '../../miscallaneous/editable/EditableNumber.Component.tsx';
 import EditablePayRate from '../../miscallaneous/editable/EditablePayRate.Component.tsx';
-import EditableToggleSwitch from '../../miscallaneous/editable/EditableToggleSwitch.Component.tsx';
 
 import DeleteServiceModal from '../../miscallaneous/modals/service/DeleteServiceModal.Component.tsx';
 
@@ -64,9 +61,6 @@ const EditService: FC<EditServiceProp> = ({ editable, deletable, service }) => {
 	const [bedsRequiredInput, setBedsRequiredInput] = useState<number | null>(
 		service.beds_required
 	);
-	const [canOverlapInput, setCanOverlapInput] = useState<boolean>(
-		service.can_overlap
-	);
 	const [colorInput, setColorInput] = useState<ServiceColor | null>(
 		service.color
 	);
@@ -97,7 +91,6 @@ const EditService: FC<EditServiceProp> = ({ editable, deletable, service }) => {
 		setFeetInput(service.feet);
 		setAcupunctureInput(service.acupuncture);
 		setBedsRequiredInput(service.beds_required);
-		setCanOverlapInput(service.can_overlap);
 		setColorInput(service.color);
 
 		setChangesMade(false);
@@ -139,8 +132,6 @@ const EditService: FC<EditServiceProp> = ({ editable, deletable, service }) => {
 			bedsRequiredInput === service.beds_required
 				? undefined
 				: bedsRequiredInput;
-		const can_overlap: boolean | undefined =
-			canOverlapInput === service.can_overlap ? undefined : canOverlapInput;
 		const color: ServiceColor | null | undefined =
 			colorInput === service.color ? undefined : colorInput;
 
@@ -153,7 +144,6 @@ const EditService: FC<EditServiceProp> = ({ editable, deletable, service }) => {
 			feet !== undefined ||
 			acupuncture !== undefined ||
 			beds_required !== undefined ||
-			can_overlap !== undefined ||
 			color !== undefined;
 
 		setChangesMade(changesMade);
@@ -179,7 +169,6 @@ const EditService: FC<EditServiceProp> = ({ editable, deletable, service }) => {
 		feetInput,
 		acupunctureInput,
 		bedsRequiredInput,
-		canOverlapInput,
 		colorInput,
 	]);
 
@@ -233,8 +222,6 @@ const EditService: FC<EditServiceProp> = ({ editable, deletable, service }) => {
 			bedsRequiredInput === service.beds_required
 				? undefined
 				: (bedsRequiredInput as number);
-		const can_overlap: boolean | undefined =
-			canOverlapInput === service.can_overlap ? undefined : canOverlapInput;
 		const color: ServiceColor | undefined =
 			colorInput === service.color ? undefined : (colorInput as ServiceColor);
 
@@ -248,7 +235,6 @@ const EditService: FC<EditServiceProp> = ({ editable, deletable, service }) => {
 			...(feet !== undefined && { feet }),
 			...(acupuncture !== undefined && { acupuncture }),
 			...(beds_required !== undefined && { beds_required }),
-			...(can_overlap !== undefined && { can_overlap }),
 			...(color !== undefined && { color }),
 		};
 
@@ -392,19 +378,6 @@ const EditService: FC<EditServiceProp> = ({ editable, deletable, service }) => {
 					requiredMessage: ERRORS.service.beds_required.required,
 				}}
 				placeholder={PLACEHOLDERS.service.beds_required}
-				editable={editable}
-				missingPermissionMessage={ERRORS.service.permissions.edit}
-			/>
-
-			<EditableToggleSwitch
-				originalChecked={service.can_overlap}
-				setChecked={setCanOverlapInput}
-				checked={canOverlapInput}
-				falseText={t('Cannot Overlap')}
-				trueText={t('Can Overlap')}
-				toggleColour={ToggleColor.BLUE}
-				label={LABELS.service.can_overlap}
-				name={NAMES.service.can_overlap}
 				editable={editable}
 				missingPermissionMessage={ERRORS.service.permissions.edit}
 			/>


### PR DESCRIPTION
- Reservations that overlap will now show a warning, but will still allow the user to place the reservations.
- Reservations that are completely overlapped by another reservation will not shift right so it is accessible.